### PR TITLE
feat: Add `highlighttable` class for custom table `:target` styling

### DIFF
--- a/styles/citizen/shared/common.scss
+++ b/styles/citizen/shared/common.scss
@@ -75,3 +75,21 @@ a.image:hover:not(.lazy):not(.new) > img {
   background-color: $color-emphasized;
   opacity: $opacity-icon-base;
 }
+
+// Used for highlighting (anchor) target table row. Just add "highlighttable" to your table's class attribute.
+table.highlighttable {
+  tr:target {
+    animation: highlighttable 3s ease-in-out;
+  }
+  td:target {
+    animation: highlighttable 3s ease-in-out;
+  }
+}
+@keyframes highlighttable {
+    from {
+        background-color: rgba(255, 255, 0, 0.3);
+    }
+    to {
+        background-color: rgba(255, 255, 0, 0);
+    }
+}

--- a/styles/citizen/shared/common.scss
+++ b/styles/citizen/shared/common.scss
@@ -78,11 +78,10 @@ a.image:hover:not(.lazy):not(.new) > img {
 
 // Used for highlighting (anchor) target table row. Just add "highlighttable" to your table's class attribute.
 table.highlighttable {
-  tr:target {
-    animation: highlighttable 3s ease-in-out;
-  }
-  td:target {
-    animation: highlighttable 3s ease-in-out;
+  tr, td {
+    &:target {
+      animation: highlighttable 3s ease-in-out;
+    }
   }
 }
 @keyframes highlighttable {


### PR DESCRIPTION
Adds styling to highlight table rows and table data cells when clicking on an anchor link that takes you to it.
https://repair.wiki/w/Steam_Deck_Mainboard_Testing_Points#a301

Could either go for animated highlight, or just a static highlight that keeps the background color. If so, move `background-color: rgba(255, 255, 0, 0.3);` to inside `&:target { }`.