### PR TITLE
Added styling to fix weird behavour with frontpage buttons

### DIFF
--- a/styles/citizen/pages/main.scss
+++ b/styles/citizen/pages/main.scss
@@ -38,6 +38,16 @@
   }
 }
 
+.frontpage-image-button.has-image a {
+  align-items: normal;
+}
+
+@media screen and (max-width: 1024px) {
+  .frontpage-container-row:has(.frontpage-image-button) {
+    justify-content: center;
+  }
+}
+
 // Fix to make the google bar match with everything else
 button.gsc-search-button {
   border-radius: $border-radius--small !important;


### PR DESCRIPTION
Frontpage buttons has these weird behaviors at some screen 
![image](https://github.com/user-attachments/assets/69ba1357-0902-49ac-b15c-af3af1b39680)
![image](https://github.com/user-attachments/assets/f3df40e8-70f3-420e-a421-c899502367d7)

This SCSS fixes it and makes it look this instead.
![image](https://github.com/user-attachments/assets/43a3b6ca-2e15-4bea-b8e7-7e05fae79024)
![image](https://github.com/user-attachments/assets/71d6cfd0-841a-46a6-ade4-bc5fd25b66c3)


